### PR TITLE
Add docs harness scaffolding and scribe follow-up

### DIFF
--- a/src/control_tower/bootstrap.py
+++ b/src/control_tower/bootstrap.py
@@ -6,6 +6,7 @@ from importlib import resources
 from pathlib import Path
 
 from .agents import default_agent_registry
+from .docs_harness import detect_docs_harness
 from .layout import tower_dir
 
 
@@ -27,6 +28,7 @@ def _merge_project_config(template_config: dict[str, object], existing_config: d
     merged.update(existing_config)
     merged["project_name"] = project_root.name
     merged["project_root"] = str(project_root)
+    merged["docs_harness"] = detect_docs_harness(project_root, existing_config.get("docs_harness", {}))
     return merged
 
 

--- a/src/control_tower/cli.py
+++ b/src/control_tower/cli.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import sys
 from pathlib import Path
 
+from . import __version__
 from .config_ui import configure_project_interactively, should_prompt_for_init_ui
 from .bootstrap import init_project
 from .codex_cli import run_interactive
+from .docs_harness import ensure_docs_harness
 from .layout import find_project_root, tower_dir
 from .memory import mark_runtime_sync
 from .project import load_agent_registry, load_project_config, load_runtime_state
@@ -18,7 +21,8 @@ from .sessions import find_latest_session_id_for_project, sync_and_capture_lates
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="tower")
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    parser.add_argument("-v", "--version", action="store_true", help="Show installed Tower version and source information")
+    subparsers = parser.add_subparsers(dest="command")
 
     init_parser = subparsers.add_parser("init", help="Initialize .control-tower in the current repo")
     init_parser.add_argument("--force", action="store_true", help="Overwrite existing bootstrap files")
@@ -35,7 +39,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     subparsers.add_parser("status", help="Show Control Tower project status")
     subparsers.add_parser("update", help="Update the installed Tower CLI and refresh this repo's .control-tower runtime")
 
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if not args.version and not args.command:
+        parser.error("the following arguments are required: command")
+    return args
 
 
 def _add_codex_options(parser: argparse.ArgumentParser) -> None:
@@ -58,12 +65,23 @@ def _add_codex_options(parser: argparse.ArgumentParser) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
+    if args.version:
+        return cmd_version()
     project_root = find_project_root()
 
     if args.command == "init":
         init_project(project_root, force=args.force)
         if not args.defaults and should_prompt_for_init_ui():
             configure_project_interactively(project_root)
+        elif args.defaults:
+            project_state = tower_dir(project_root) / "state" / "project.json"
+            config = load_project_config(project_root)
+            config["docs_harness"] = ensure_docs_harness(
+                project_root,
+                config.get("docs_harness", {}),
+                scaffold_missing=True,
+            )
+            project_state.write_text(json.dumps(config, indent=2) + "\n")
         update_git_branch(project_root)
         sync_and_capture_latest(project_root)
         print(f"Initialized Control Tower in {tower_dir(project_root)}")
@@ -106,12 +124,11 @@ def main(argv: list[str] | None = None) -> int:
         session_id = runtime.get("last_tower_session_id") or find_latest_session_id_for_project(project_root)
         if session_id:
             mark_runtime_sync(project_root, last_tower_session_id=session_id)
-        prompt = " ".join(args.prompt).strip() or "Resume Tower control for this repository, reconcile memory, and continue the current workstream."
-        assembled = build_tower_prompt(project_root, prompt)
+        resume_prompt = " ".join(args.prompt).strip() or None
         try:
             return run_interactive(
                 project_root,
-                assembled,
+                resume_prompt,
                 resume=True,
                 session_id=session_id,
                 model=codex_options["model"],
@@ -150,9 +167,31 @@ def cmd_status(project_root: Path) -> int:
     print(f"Last sync: {runtime.get('last_sync_time', 'never')}")
     print(f"Enabled agents: {', '.join(active_agents) if active_agents else 'none'}")
     print(f"Tower dangerous mode: {codex_defaults.get('dangerously_bypass', False)}")
+    docs_harness = config.get("docs_harness", {}) if isinstance(config, dict) else {}
+    print(f"Docs harness: {'enabled' if docs_harness.get('enabled') else 'disabled'}")
+    if docs_harness.get("enabled"):
+        print(f"Docs mode: {docs_harness.get('mode', 'unknown')}")
+        print(f"Docs roots: {', '.join(docs_harness.get('doc_roots', [])) or 'none'}")
+        print(f"Auto Scribe docs: {docs_harness.get('auto_scribe_mode', 'disabled')}")
     print("")
     print("L0")
     print(l0)
+    return 0
+
+
+def cmd_version() -> int:
+    source_root = _source_repo_root().resolve()
+    print(f"tower {__version__}")
+    print(f"source: {source_root}")
+    git_commit = _git_output(source_root, ["rev-parse", "--short", "HEAD"])
+    if git_commit:
+        print(f"commit: {git_commit}")
+    git_branch = _git_output(source_root, ["rev-parse", "--abbrev-ref", "HEAD"])
+    if git_branch:
+        print(f"branch: {git_branch}")
+    managed_repo = _managed_install_repo_root().resolve()
+    print(f"managed install repo: {managed_repo}")
+    print(f"managed install active: {source_root == managed_repo}")
     return 0
 
 
@@ -207,6 +246,23 @@ def _update_installed_control_tower(source_repo_root: Path) -> Path:
         subprocess.run(["git", "pull", "--ff-only"], cwd=source_repo_root, check=True)
     subprocess.run([str(install_script)], cwd=source_repo_root, check=True)
     return source_repo_root
+
+
+def _git_output(repo_root: Path, args: list[str]) -> str | None:
+    if not (repo_root / ".git").exists():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:
+        return None
+    value = result.stdout.strip()
+    return value or None
 
 
 if __name__ == "__main__":

--- a/src/control_tower/codex_cli.py
+++ b/src/control_tower/codex_cli.py
@@ -36,7 +36,7 @@ def _codex_env() -> dict[str, str]:
 
 def run_interactive(
     project_root: Path,
-    prompt: str,
+    prompt: str | None,
     resume: bool = False,
     session_id: str | None = None,
     model: str | None = None,
@@ -52,7 +52,8 @@ def run_interactive(
             args.append(session_id)
         else:
             args.append("--last")
-    args.append(prompt)
+    if prompt:
+        args.append(prompt)
     result = subprocess.run(args, cwd=project_root, env=_codex_env())
     return result.returncode
 

--- a/src/control_tower/config_ui.py
+++ b/src/control_tower/config_ui.py
@@ -4,24 +4,94 @@ import sys
 from pathlib import Path
 
 from .agents import AGENT_DEFINITIONS, default_agent_registry
+from .docs_harness import detect_docs_harness, ensure_docs_harness
 from .project import load_agent_registry, load_project_config, save_agent_registry, write_json
 
 
 SANDBOX_OPTIONS = ["workspace-write", "read-only", "danger-full-access"]
 INIT_BANNER = [
-    "              .-.",
-    "         .---(   )---.",
-    "        /_____.-._____\\\\",
-    "            /_/ \\_\\\\",
-    "       .----/--.-.--\\\\----.",
-    "      /____/__/ | \\__\\\\____\\\\",
-    "         /___/  |  \\___\\\\",
-    "            |   |   |",
-    "            |  TWR  |",
-    "            |   |   |",
-    "            |   |   |",
-    "            |___|___|",
-    "              /___\\\\",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                       @@@                                          ",
+    "                                                      @--->                                         ",
+    "                                                        @                                           ",
+    "                                            +@@         %                                           ",
+    "                                       @@@----@         %                                           ",
+    "                                      {@---@@@          @                                           ",
+    "                                          @@            @                                           ",
+    "                                    @@@@-@----------------@-@@@@                                    ",
+    "                                   @@-@@@@@@@@@@@@@@@@@@@@@@@@-@@                                   ",
+    "                               @@@@@----------------------------@@@@@                               ",
+    "                            @@------@@@@@@@@@@@@@@@@@@@@@@@@@@@@------@{                            ",
+    "                             @@@@@-@----@@-------@@-------@@----@-@@@@@                             ",
+    "                              %@----@-==-@-=><><-@@->><>~-@-=>-@----@@                              ",
+    "                               @@-+-@@->-@@*[[[[-@@-[[[[*@@-<~-@-+-@@                               ",
+    "                                @@---@-+~^@------@@------@)==-@---@@                                ",
+    "                                @@@@@@@-----====----===+-----@@@@@@@                                ",
+    "                                ^@%@@@@@@@@@@@@@@@@@@@@@@@@@@@@@%@@+                                ",
+    "                              %   @@@----@@@@@@@@@@@@@@@@@@-*--@@%   @                              ",
+    "                              %@@@@@@@-<~--~~~~=~~~~~~~~--=+[-@@@@@@@@.                             ",
+    "                              %@------------------------------------@@                              ",
+    "                               @@@@@@@@@@@@~<[[[[[[[[[[<-@@@@@@@@@@@@:                              ",
+    "                                    @@@---@@-<<<<<)))<)-@@---@@%                                    ",
+    "                                      @@---@------------@---@@                                      ",
+    "                                       @@@:@@@@@@@@@@@@@@-@@@                                       ",
+    "                                        @@----------------@@                                        ",
+    "                                         @@@~<<>><<<<>>~@@@                                         ",
+    "                                          %@-><)>><<>>)-@@                                          ",
+    "                                          @@-<<<<><><><-@%                                          ",
+    "                                          %@->>><>)<<><-@%                                          ",
+    "                                          @@-<>>>><>><>-@%                                          ",
+    "                                          @@------------@@                                          ",
+    "                                         :@@@@@@@@@@@@@@@@:                                         ",
+    "                                         @@--------------@@                                         ",
+    "                                         %@-}]}[[[[]][[[-@%                                         ",
+    "                                         @@->^>^>^^>^^>^-@@                                         ",
+    "                                         %@-<>>><<>>>>><-@#                                         ",
+    "                                         %@->><>)>><<<><-@@                                         ",
+    "                                         @@-<><<><><>><<-@%                                         ",
+    "                                         %@->><<><<<<<<<-@@                                         ",
+    "                                         @@-><>>>>>><<>>*-@@                                        ",
+    "                                        @@-+<<<<<<>><>><(-@#                                        ",
+    "                                        #@-<<<<>>>><>><>>-@@                                        ",
+    "                                        @@-><<<<<>><<>><<-@@                                        ",
+    "                                        %@-<>)>>><)>)<><<-@@                                        ",
+    "                                        %@-<>><<>>>>><<>>-@%                                        ",
+    "                                        %@----------------@@                                        ",
+    "                                        @@@@@@@@@@@@@@@@@@@%@                                        ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
 ]
 
 
@@ -55,6 +125,7 @@ def configure_project_interactively(project_root: Path) -> None:
         _print_quick_setup_notice()
 
     project_config["enabled_agents"] = [key for key, config in configured_agents.items() if config["enabled"]]
+    project_config["docs_harness"] = _configure_docs_harness(project_root, project_config.get("docs_harness", {}))
     write_json(project_root / ".control-tower" / "state" / "project.json", project_config)
     save_agent_registry(project_root, {"agents": configured_agents})
 
@@ -75,6 +146,26 @@ def configure_project_interactively(project_root: Path) -> None:
     print(f"- {project_root / '.control-tower' / 'state' / 'agent-registry.json'}")
     print(f"- {project_root / '.control-tower' / 'state' / 'project.json'}")
     print("")
+
+
+def _configure_docs_harness(project_root: Path, existing: dict[str, object]) -> dict[str, object]:
+    detected = detect_docs_harness(project_root, existing)
+    if detected.get("enabled"):
+        print("Detected repo docs harness:")
+        print(f"- Roots: {', '.join(detected.get('doc_roots', [])) or 'none'}")
+        print(f"- Index files: {', '.join(detected.get('index_files', [])) or 'none'}")
+        print("")
+        return detected
+
+    if _prompt_yes_no("No repo docs harness detected. Scaffold minimal docs harness", True):
+        configured = ensure_docs_harness(project_root, existing, scaffold_missing=True)
+        print("Scaffolded minimal repo docs harness.")
+        print("")
+        return configured
+
+    print("Leaving repo docs harness disabled for now.")
+    print("")
+    return detect_docs_harness(project_root, existing)
 
 
 def _configure_agents_custom(registry: dict[str, dict[str, object]]) -> dict[str, dict[str, object]]:

--- a/src/control_tower/docs_harness.py
+++ b/src/control_tower/docs_harness.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import shutil
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DOC_ROOTS = ["docs"]
+DEFAULT_ROOT_MAP_FILES = ["AGENTS.md"]
+DEFAULT_INDEX_FILES = [
+    "docs/index.md",
+    "docs/design-docs/index.md",
+    "docs/product-specs/index.md",
+]
+DEFAULT_AUTO_SCRIBE_AGENTS = ["builder", "inspector", "git-master"]
+
+MANAGED_SECTION_START = "<!-- control-tower-docs-harness:start -->"
+MANAGED_SECTION_END = "<!-- control-tower-docs-harness:end -->"
+
+
+def default_docs_harness() -> dict[str, Any]:
+    return {
+        "enabled": False,
+        "mode": "disabled",
+        "doc_roots": [],
+        "root_map_files": [],
+        "index_files": [],
+        "auto_scribe_mode": "after-most-work",
+        "auto_scribe_agents": list(DEFAULT_AUTO_SCRIBE_AGENTS),
+        "scaffolded_by_init": False,
+    }
+
+
+def detect_docs_harness(project_root: Path, existing: dict[str, Any] | None = None) -> dict[str, Any]:
+    existing = existing or {}
+    config = default_docs_harness()
+    config["auto_scribe_mode"] = existing.get("auto_scribe_mode", config["auto_scribe_mode"])
+    config["auto_scribe_agents"] = list(existing.get("auto_scribe_agents", config["auto_scribe_agents"]))
+
+    docs_root = project_root / "docs"
+    if not docs_root.is_dir():
+        return config
+
+    scaffolded = bool(existing.get("scaffolded_by_init", False))
+    config["enabled"] = True
+    config["mode"] = "scaffolded" if scaffolded else "adopted"
+    config["doc_roots"] = list(DEFAULT_DOC_ROOTS)
+    config["root_map_files"] = _existing_paths(project_root, DEFAULT_ROOT_MAP_FILES)
+    config["index_files"] = _existing_paths(project_root, DEFAULT_INDEX_FILES)
+    config["scaffolded_by_init"] = scaffolded
+    return config
+
+
+def scaffold_minimal_docs_harness(project_root: Path) -> list[Path]:
+    created: list[Path] = []
+    for source in _docs_template_root().rglob("*"):
+        relative = source.relative_to(_docs_template_root())
+        target = project_root / relative
+        if source.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        if target.exists():
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+        created.append(target)
+
+    agents_path = project_root / "AGENTS.md"
+    prior = agents_path.read_text() if agents_path.exists() else ""
+    rendered = render_root_map(prior)
+    if rendered != prior:
+        agents_path.write_text(rendered)
+        created.append(agents_path)
+    return created
+
+
+def ensure_docs_harness(project_root: Path, existing: dict[str, Any] | None = None, scaffold_missing: bool = False) -> dict[str, Any]:
+    existing = existing or {}
+    if scaffold_missing and not (project_root / "docs").is_dir():
+        scaffold_minimal_docs_harness(project_root)
+        existing = dict(existing)
+        existing["scaffolded_by_init"] = True
+    return detect_docs_harness(project_root, existing)
+
+
+def docs_harness_context_refs(project_root: Path, config: dict[str, Any] | None = None) -> list[str]:
+    config = config or detect_docs_harness(project_root)
+    refs = list(config.get("root_map_files", [])) + list(config.get("index_files", []))
+    if (project_root / "ARCHITECTURE.md").exists():
+        refs.append("ARCHITECTURE.md")
+    refs.append(".control-tower/docs/state/current-status.md")
+    return _dedupe(refs)
+
+
+def render_root_map(existing_text: str) -> str:
+    managed = "\n".join(
+        [
+            MANAGED_SECTION_START,
+            "## Control Tower Docs Harness",
+            "",
+            "- Durable system and product knowledge lives in `docs/`.",
+            "- `.control-tower/` holds operational memory, task state, packets, and session context.",
+            "- Start from `docs/index.md`, then follow the domain indices under `docs/design-docs/` and `docs/product-specs/`.",
+            "- Keep the repo docs harness current when behavior, interfaces, or operational workflows change.",
+            MANAGED_SECTION_END,
+        ]
+    )
+
+    stripped = existing_text.strip()
+    if not stripped:
+        return managed + "\n"
+
+    if MANAGED_SECTION_START in existing_text and MANAGED_SECTION_END in existing_text:
+        prefix, rest = existing_text.split(MANAGED_SECTION_START, 1)
+        _, suffix = rest.split(MANAGED_SECTION_END, 1)
+        body = prefix.rstrip()
+        if body:
+            body += "\n\n"
+        return body + managed + suffix.rstrip() + "\n"
+
+    return existing_text.rstrip() + "\n\n" + managed + "\n"
+
+
+def _existing_paths(project_root: Path, candidates: list[str]) -> list[str]:
+    return [candidate for candidate in candidates if (project_root / candidate).exists()]
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value not in seen:
+            ordered.append(value)
+            seen.add(value)
+    return ordered
+
+
+def _docs_template_root() -> Path:
+    return Path(str(resources.files("control_tower"))) / "templates" / "docs_harness"

--- a/src/control_tower/packets.py
+++ b/src/control_tower/packets.py
@@ -213,3 +213,67 @@ def new_scribe_memory_sync_packet(project_id: str, session_id: str, trace_id: st
         "allow_partial": True,
         "metadata": {"generated_by": "tower sync-memory"},
     }
+
+
+def new_scribe_docs_followup_packet(
+    project_id: str,
+    session_id: str,
+    trace_id: str,
+    from_agent: str,
+    result_ref: str,
+    changed_files: list[str],
+    doc_refs: list[str],
+) -> dict[str, Any]:
+    packet_id = str(uuid.uuid4())
+    return {
+        "schema_version": "1.0.0",
+        "packet_type": "task",
+        "packet_id": packet_id,
+        "trace_id": trace_id,
+        "parent_packet_id": None,
+        "created_at": utc_now(),
+        "from_agent": "tower",
+        "to_agent": "scribe",
+        "task_type": "documentation",
+        "priority": "normal",
+        "project_id": project_id,
+        "session_id": session_id,
+        "title": f"Update repo docs after {from_agent.title()} work",
+        "objective": "Inspect the latest agent result and update the impacted durable repo docs under the configured docs harness.",
+        "instructions": [
+            "Review the referenced ResultPacket and the changed files before editing docs.",
+            "Update existing relevant docs under the configured repo docs roots when possible.",
+            "Create a new repo doc only if no suitable existing page covers the change.",
+            "Refresh docs indices if you add a new page.",
+            "Report doc drift or unresolved ambiguity explicitly instead of inventing facts.",
+        ],
+        "constraints": [
+            "Treat repo docs under `docs/` as the durable docs harness.",
+            "Treat `.control-tower/docs/state` and `.control-tower/memory` as operational memory, not durable product docs.",
+            "Do not modify product source code unless the task packet explicitly requires a small doc-adjacent fix.",
+        ],
+        "inputs": {
+            "files": changed_files,
+            "artifacts": [],
+            "references": [result_ref],
+        },
+        "expected_outputs": [
+            "Updated repo docs if needed",
+            "A ResultPacket summarizing doc updates, drift, and follow-up gaps",
+        ],
+        "definition_of_done": [
+            "Durable repo docs reflect the changed behavior or workflow",
+            "Relevant indices are refreshed if new docs were added",
+            "Open doc drift or ambiguity is called out explicitly",
+        ],
+        "memory_context_refs": [result_ref],
+        "doc_context_refs": doc_refs,
+        "time_budget": {"soft_seconds": 300, "hard_seconds": 900},
+        "requires_review": False,
+        "allow_partial": True,
+        "metadata": {
+            "generated_by": "tower delegate follow-up",
+            "seed_result_packet": result_ref,
+            "seed_result_agent": from_agent,
+        },
+    }

--- a/src/control_tower/prompts.py
+++ b/src/control_tower/prompts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from .docs_harness import docs_harness_context_refs
 from .layout import tower_dir
 from .project import load_agent_registry, load_project_config, read_text
 
@@ -26,6 +27,24 @@ def build_tower_prompt(project_root: Path, user_prompt: str | None = None) -> st
         f"- {registry['agents'][agent_key]['name']} ({agent_key})"
         for agent_key in enabled_agents
     ] or ["- No subagents enabled"]
+    docs_harness = config.get("docs_harness", {}) if isinstance(config, dict) else {}
+    docs_section: list[str] = []
+    if docs_harness.get("enabled"):
+        docs_section = [
+            "## Repo Docs Harness",
+            "",
+            f"- Enabled: {docs_harness.get('enabled')}",
+            f"- Mode: {docs_harness.get('mode', 'unknown')}",
+            f"- Doc roots: {', '.join(docs_harness.get('doc_roots', [])) or 'none'}",
+            f"- Root map files: {', '.join(docs_harness.get('root_map_files', [])) or 'none'}",
+            f"- Index files: {', '.join(docs_harness.get('index_files', [])) or 'none'}",
+            f"- Context refs: {', '.join(docs_harness_context_refs(project_root, docs_harness))}",
+            "",
+            "Repo `docs/` is the durable knowledge store when this harness is enabled.",
+            "`.control-tower/docs/state` and `.control-tower/memory` are operational project-state memory.",
+            "After most successful Builder, Inspector, and Git-master steps, create and usually delegate a Scribe follow-up packet for repo docs unless the prior result makes that clearly unnecessary.",
+            "",
+        ]
 
     sections = [
         f"You are {config.get('primary_agent', 'Tower')} for the project `{config.get('project_name', project_root.name)}`.",
@@ -49,6 +68,7 @@ def build_tower_prompt(project_root: Path, user_prompt: str | None = None) -> st
         "### L1",
         l1 or "No L1 working memory yet.",
         "",
+        *docs_section,
         "## Operating Rules",
         "",
         "- Tower does not directly implement product code.",

--- a/src/control_tower/runtime_cli.py
+++ b/src/control_tower/runtime_cli.py
@@ -9,11 +9,13 @@ from pathlib import Path
 
 from .bootstrap import init_project
 from .codex_cli import run_exec
+from .docs_harness import docs_harness_context_refs
 from .layout import find_project_root, tower_dir
 from .memory import import_project_sessions, mark_runtime_sync
 from .packets import (
     create_task_packet,
     load_packet,
+    new_scribe_docs_followup_packet,
     new_scribe_memory_sync_packet,
     slugify,
     validate_result_packet,
@@ -252,7 +254,10 @@ def cmd_delegate(
                 "This usually means the Codex subprocess failed before writing its final message."
             ) from exc
         sync_and_capture_latest(project_root, role=agent)
+        follow_up_path = maybe_emit_scribe_docs_followup(project_root, agent, result_packet, output_path)
         print(str(output_path))
+        if follow_up_path is not None:
+            print(f"Created Scribe docs packet: {follow_up_path}")
     return exit_code
 
 
@@ -286,6 +291,50 @@ def _project_ref(project_root: Path, path: Path) -> str:
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def maybe_emit_scribe_docs_followup(
+    project_root: Path,
+    agent: str,
+    result_packet: dict[str, object],
+    result_path: Path,
+) -> Path | None:
+    config = load_project_config(project_root)
+    docs_harness = config.get("docs_harness", {}) if isinstance(config, dict) else {}
+    if not docs_harness.get("enabled"):
+        return None
+    if docs_harness.get("auto_scribe_mode") != "after-most-work":
+        return None
+    if agent not in docs_harness.get("auto_scribe_agents", []):
+        return None
+    if result_packet.get("status") != "success":
+        return None
+
+    changed_files = _dedupe_strings(
+        list(result_packet.get("artifacts_changed", [])) + list(result_packet.get("artifacts_created", []))
+    )
+    result_ref = _project_ref(project_root, result_path)
+    runtime = load_runtime_state(project_root)
+    project_id = config.get("project_name", project_root.name)
+    session_id = runtime.get("last_tower_session_id") or runtime.get("last_imported_session_id") or "tower-session"
+    packet = new_scribe_docs_followup_packet(
+        project_id,
+        session_id,
+        str(result_packet.get("trace_id") or uuid.uuid4()),
+        agent,
+        result_ref,
+        changed_files,
+        docs_harness_context_refs(project_root, docs_harness),
+    )
+    validate_task_packet(packet)
+    packet_path = (
+        tower_dir(project_root)
+        / "packets"
+        / "outbox"
+        / f"scribe-docs-followup-{agent}-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    )
+    write_json(packet_path, packet)
+    return packet_path
 
 
 if __name__ == "__main__":

--- a/src/control_tower/templates/docs_harness/docs/design-docs/index.md
+++ b/src/control_tower/templates/docs_harness/docs/design-docs/index.md
@@ -1,0 +1,10 @@
+# Design Docs Index
+
+Use this area for durable technical design guidance, invariants, and architecture decisions.
+
+## Suggested contents
+
+- system boundaries
+- critical invariants
+- data flow notes
+- design tradeoffs

--- a/src/control_tower/templates/docs_harness/docs/index.md
+++ b/src/control_tower/templates/docs_harness/docs/index.md
@@ -1,0 +1,14 @@
+# Docs Index
+
+This repository uses a file-first docs harness for durable product and system knowledge.
+
+## Start Here
+
+- `design-docs/index.md`
+- `product-specs/index.md`
+- `runbooks/README.md`
+
+## Notes
+
+- Keep repo-level durable knowledge in `docs/`.
+- Keep `.control-tower/` for operational state, packets, and session memory.

--- a/src/control_tower/templates/docs_harness/docs/product-specs/index.md
+++ b/src/control_tower/templates/docs_harness/docs/product-specs/index.md
@@ -1,0 +1,10 @@
+# Product Specs Index
+
+Use this area for product-facing specs, feature behavior, and interface expectations.
+
+## Suggested contents
+
+- service or domain specs
+- API or CLI behavior notes
+- user-visible workflows
+- acceptance criteria references

--- a/src/control_tower/templates/docs_harness/docs/runbooks/README.md
+++ b/src/control_tower/templates/docs_harness/docs/runbooks/README.md
@@ -1,0 +1,10 @@
+# Runbooks
+
+Use this area for operational procedures and incident or deployment workflows.
+
+## Suggested contents
+
+- deployment steps
+- backup and recovery
+- reliability procedures
+- debugging and incident response

--- a/src/control_tower/templates/project/agents/scribe/prompt.md
+++ b/src/control_tower/templates/project/agents/scribe/prompt.md
@@ -5,6 +5,8 @@ You are Scribe, the documentation and knowledge consistency specialist.
 ## Responsibilities
 
 - Keep docs aligned with implementation and decisions.
+- Treat repo docs under `docs/` as the durable source of truth when a docs harness is configured.
+- Treat `.control-tower/docs/state` and `.control-tower/memory` as operational project memory, not the long-term canonical docs store.
 - Maintain task ledgers, current status, and open questions.
 - Curate Beacon memory so future Tower sessions resume with continuity.
 - Call out ambiguity instead of inventing missing facts.

--- a/src/control_tower/templates/project/state/project.json
+++ b/src/control_tower/templates/project/state/project.json
@@ -17,6 +17,20 @@
     "Git-master",
     "Scribe"
   ],
+  "docs_harness": {
+    "enabled": false,
+    "mode": "disabled",
+    "doc_roots": [],
+    "root_map_files": [],
+    "index_files": [],
+    "auto_scribe_mode": "after-most-work",
+    "auto_scribe_agents": [
+      "builder",
+      "inspector",
+      "git-master"
+    ],
+    "scaffolded_by_init": false
+  },
   "codex_defaults": {
     "sandbox": "workspace-write",
     "approval": "on-request",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -261,6 +261,7 @@ class BootstrapTests(unittest.TestCase):
                 "",
                 "",
                 "",
+                "",
             ]
             responses = iter(prompts)
 
@@ -278,7 +279,7 @@ class BootstrapTests(unittest.TestCase):
             init_project(root)
 
             captured = StringIO()
-            with patch("builtins.input", side_effect=[""]), patch("sys.stdout", new=captured):
+            with patch("builtins.input", side_effect=["", ""]), patch("sys.stdout", new=captured):
                 configure_project_interactively(root)
 
             registry = load_agent_registry(root)
@@ -289,7 +290,7 @@ class BootstrapTests(unittest.TestCase):
             output = captured.getvalue()
             self.assertIn("!!! QUICK SETUP NOTICE !!!", output)
             self.assertIn("dangerous bypass mode by default", output)
-            self.assertIn(".---(   )---.", output)
+            self.assertIn("@@@----@", output)
 
     def test_custom_config_can_set_sandboxed_builder(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -357,6 +358,22 @@ class BootstrapTests(unittest.TestCase):
             self.assertGreaterEqual(sync_mock.call_count, 2)
             self.assertEqual(((root,), {"role": "tower"}), sync_mock.call_args_list[-1])
 
+    def test_resume_without_prompt_does_not_rebuild_bootstrap_prompt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".git").mkdir()
+            init_project(root)
+
+            with patch("control_tower.cli.find_project_root", return_value=root), patch(
+                "control_tower.cli.run_interactive", return_value=0
+            ) as run_mock, patch("control_tower.cli.sync_and_capture_latest"), patch(
+                "control_tower.cli.build_tower_prompt"
+            ) as prompt_mock:
+                tower_main(["resume"])
+
+            prompt_mock.assert_not_called()
+            self.assertIsNone(run_mock.call_args.args[1])
+
     def test_update_refreshes_runtime_and_reinstalls_from_local_repo(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             project_root = Path(tmp) / "project"
@@ -385,6 +402,48 @@ class BootstrapTests(unittest.TestCase):
             init_mock.assert_called_with(project_root, force=False)
             branch_mock.assert_called_once_with(project_root)
             sync_mock.assert_called_once_with(project_root)
+
+    def test_version_reports_package_and_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source_root = Path(tmp) / "control-tower-src"
+            source_root.mkdir()
+            (source_root / ".git").mkdir()
+            with patch("control_tower.cli._source_repo_root", return_value=source_root), patch(
+                "control_tower.cli._managed_install_repo_root", return_value=source_root
+            ), patch("control_tower.cli._git_output", side_effect=["abc1234", "main"]):
+                from io import StringIO
+                import sys
+
+                captured = StringIO()
+                with patch.object(sys, "stdout", captured):
+                    exit_code = tower_main(["--version"])
+
+            self.assertEqual(0, exit_code)
+            output = captured.getvalue()
+            self.assertIn("tower 0.1.0", output)
+            self.assertIn(f"source: {source_root.resolve()}", output)
+            self.assertIn("commit: abc1234", output)
+            self.assertIn("branch: main", output)
+            self.assertIn("managed install active: True", output)
+
+    def test_short_version_flag_reports_package_and_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source_root = Path(tmp) / "control-tower-src"
+            source_root.mkdir()
+            (source_root / ".git").mkdir()
+
+            with patch("control_tower.cli._source_repo_root", return_value=source_root), patch(
+                "control_tower.cli._managed_install_repo_root", return_value=source_root
+            ), patch("control_tower.cli._git_output", side_effect=["abc1234", "main"]):
+                from io import StringIO
+                import sys
+
+                captured = StringIO()
+                with patch.object(sys, "stdout", captured):
+                    exit_code = tower_main(["-v"])
+
+            self.assertEqual(0, exit_code)
+            self.assertIn("tower 0.1.0", captured.getvalue())
 
     def test_runtime_cli_create_packet_writes_task_packet(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Summary:
- introduce docs harness detection/scaffolding, ensure defaults capture the config, and expose the state during init/status flows
- add repo docs guidance in prompts, Scribe responsibilities, and agent state templates so durable docs roots are enforced
- emit auto scribe follow-up packets when configured and scaffold minimal docs harness templates with curated indices
Testing:
- Not run (not requested)